### PR TITLE
Correct error in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fork of https://github.com/spin83/multi-monitors-add-on rewritten (almost) from 
 
 ```sh
 # clone repo
-git clone git@github.com:lazanet/multi-monitors-add-on.git
+git clone https://github.com/lazanet/multi-monitors-add-on.git
 # cd into cloned repo
 cd multi-monitors-add-on
 # create a local shared gnome shell extensions dir


### PR DESCRIPTION
Using the current "git clone" command, I get the following error message:
`git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.`

The command suggested in this pull request works without any such error message.